### PR TITLE
Update the composer homepage and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Parable is a PHP framework with two goals: it's just enough, and it doesn't enfo
 Php 8.0+ and [composer](https://getcomposer.org) are required.
 
 ```bash
-$ composer require parable-php/parable
+$ composer require parable-php/framework
 ```
 
 And to set up parable, run the following and follow the interactive questions:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "minimal",
         "parable"
     ],
-    "homepage": "https://github.com/parable-php/parable",
+    "homepage": "https://github.com/parable-php/framework",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
The old instructions to use `composer require parable-php/parable` doesn't work. Instead, it should be `composer require parable-php/framework`.